### PR TITLE
[WIP] adding subscribe_to_puzzle functionality

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -11677,15 +11677,12 @@ var createServer = (subscribers2, transportsBySessionId2) => {
           );
           const result = await performAction(args.puzzleId, args.actionName);
           if (result.success) {
-            const snapshot = getPuzzleSnapshot(args.puzzleId);
-            const newState = snapshot.currentState;
             const subscribedTransports = subscribers2.get(args.puzzleId) || /* @__PURE__ */ new Set();
             for (const subTransport of subscribedTransports) {
               console.log("Subscribed transport", subTransport);
-              await subTransport.send({
-                jsonrpc: "2.0",
-                method: "notifications/puzzle/state_changed",
-                params: { puzzleId: args.puzzleId, newState }
+              await mcpServer2.notification({
+                method: "notifications/resources/updated",
+                params: { uri: `puzzlebox:/puzzle/${args.puzzleId}` }
               });
             }
           }

--- a/src/puzzlebox.ts
+++ b/src/puzzlebox.ts
@@ -117,16 +117,14 @@ export const createServer = (
           );
           const result = await performAction(args.puzzleId, args.actionName);
           if (result.success) {
-            const snapshot = getPuzzleSnapshot(args.puzzleId);
-            const newState = snapshot.currentState;
             const subscribedTransports =
               subscribers.get(args.puzzleId) || new Set();
             for (const subTransport of subscribedTransports) {
-              console.log("Subscribed transport", subTransport);
+              console.log("Messaging Subscribed transport");
               await subTransport.send({
                 jsonrpc: "2.0",
-                method: "notifications/puzzle/state_changed",
-                params: { puzzleId: args.puzzleId, newState },
+                method: "notifications/resources/updated",
+                params: { uri: `puzzlebox:/puzzle/${args.puzzleId}` },
               });
             }
           }


### PR DESCRIPTION
Final straw with this approach. It was wrong. Exposing puzzles ares resources with resource list and call and not managing subscribers manually is the way.